### PR TITLE
Feature/middleware

### DIFF
--- a/lib/router.js
+++ b/lib/router.js
@@ -38,6 +38,7 @@ function Router() {
   });
 
   this.routes = routes;
+  this.commonHandlers = [];
 }
 
 /**
@@ -73,6 +74,15 @@ methods.forEach(function (method) {
 });
 
 /**
+ * Apply a list of common handlers to all routes registered on the router. All handlers will be prepended to
+ * each route's handler list when applying to the server
+ * @param handlers - can be a var-arg or list of handler functions
+ */
+Router.prototype.use = function() {
+  this.commonHandlers = this.commonHandlers.concat(getHandlersFromArgs(arguments, 0));
+};
+
+/**
  * Apply all routes from the router to the given restify server instance and adds an optional path prefix
  * @param server
  * @param prefix
@@ -92,7 +102,7 @@ Router.prototype.applyRoutes = function (server, prefix) {
           route.options.path = prefix + route.options.path;
         }
         server.log.info('Registering %s at uri %s', method.toUpperCase(), route.options.path);
-        server[method](route.options, route.handlers);
+        server[method](route.options, self.commonHandlers.concat(route.handlers));
       });
     }
   );


### PR DESCRIPTION
- Add support for common middleware via .use method
- Can call the `.use` similar to how it is used on restify server except it is scoped to the routes registered with the router
